### PR TITLE
Snippet for color log in Node

### DIFF
--- a/javascript.json
+++ b/javascript.json
@@ -19,6 +19,13 @@
 		],
 		"description": "Log output to console"
 	},
+	"Print to Node Console with pretty color": {
+		"prefix": "nlog",
+		"body": [
+			"console.log('\\x1b[${1|30m,31m,32m,33m,34m,35m,36m,37m|}%s\\x1b[0m', `${2:Message}  ${${variable}}`);"
+		],
+		"description": "Black:30m,Red:31m,Green:32m,Yellow:33m,Blue:34m,Magenta:35m,Cyan:36m,White:37m"
+	},
 	"Classic Component": {
 		"prefix": "ccomp",
 		"body": [


### PR DESCRIPTION
To enable color log in Node 

GIF:
![nodelog](https://user-images.githubusercontent.com/14100409/52155378-47225580-2637-11e9-9208-b0d11d8233c4.gif)

